### PR TITLE
Harden access flow, refresh reset, music watchdog, and read mode readability

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -122,6 +122,7 @@ body::before{content:'';position:fixed;inset:0;pointer-events:none;z-index:1;bac
 .ra-btn:focus-visible{outline:2px solid var(--cyan);outline-offset:4px}
 .ra-btn.hidden{opacity:0;pointer-events:none;transform:scale(0.8);transition:opacity 0.4s,transform 0.4s}
 .ra-password-form{display:flex;flex-direction:column;align-items:center;gap:0.75rem;margin-top:0.25rem;opacity:0;transition:opacity 0.4s ease}
+.ra-password-form[hidden]{display:none !important}
 .ra-password-form.show{opacity:1}
 .ra-password-form.hidden{opacity:0;pointer-events:none;transform:scale(0.95);transition:opacity 0.4s ease,transform 0.4s ease}
 .ra-password-label{font-family:var(--mono);font-size:0.6rem;letter-spacing:0.4em;color:var(--muted);text-transform:uppercase}
@@ -131,6 +132,7 @@ body::before{content:'';position:fixed;inset:0;pointer-events:none;z-index:1;bac
 .ra-password-input::placeholder{color:var(--muted)}
 .ra-password-input:focus{border-color:var(--cyan);box-shadow:0 0 30px rgba(24,220,255,0.4),0 0 60px rgba(24,220,255,0.15)}
 .ra-password-input.error{border-color:var(--magenta);box-shadow:0 0 25px rgba(255,46,162,0.45);animation:raShake 0.32s ease-in-out}
+.ra-password-input[aria-invalid="true"]{border-color:var(--magenta);box-shadow:0 0 25px rgba(255,46,162,0.45)}
 @keyframes raShake{0%,100%{transform:translateX(0)}20%{transform:translateX(-8px)}40%{transform:translateX(7px)}60%{transform:translateX(-5px)}80%{transform:translateX(3px)}}
 .ra-password-hint{font-family:var(--mono);font-size:0.7rem;letter-spacing:0.08em;color:var(--magenta);font-style:italic;
   margin:0.25rem 0 0;min-height:1.1em;max-width:min(380px,90vw);line-height:1.5}
@@ -1303,6 +1305,99 @@ body.read-mode .pi-link:hover{border-color:rgba(0,0,0,0.35);color:#1a1a1a}
 body.read-mode .settings-overlay{background:rgba(0,0,0,0.35)}
 body.read-mode .settings-panel{border-color:rgba(0,0,0,0.15);background:rgba(255,255,252,0.98);box-shadow:0 4px 24px rgba(0,0,0,0.12)}
 body.read-mode .settings-select{border-color:rgba(0,0,0,0.2);background:rgba(255,255,252,0.95);color:#1a1a1a}
+body.read-mode{
+  --cyan:#0f4c81;
+  --tron:#1e5b85;
+  --magenta:#7a2f5f;
+  --orange:#8a4f1a;
+  --amber:#7a5600;
+  --green:#1f6a3a;
+  --violet:#5c4ea3;
+  --red:#8f2d2d;
+  text-rendering:optimizeLegibility;
+  -webkit-font-smoothing:antialiased;
+}
+body.read-mode p,body.read-mode li{text-wrap:pretty;hyphens:auto}
+body.read-mode .section-head{
+  font-family:var(--sans);
+  font-size:clamp(1.25rem,2vw,1.55rem);
+  font-weight:700;
+  letter-spacing:0;
+  line-height:1.3;
+  margin-bottom:1rem;
+}
+body.read-mode .ts-module-header{padding:1rem 1.1rem;gap:0.7rem}
+body.read-mode .ts-module-summary{
+  font-family:var(--sans);
+  font-size:0.98rem;
+  font-weight:500;
+  letter-spacing:0;
+  color:#2f3a45;
+  white-space:normal;
+  overflow:visible;
+  text-overflow:clip;
+  line-height:1.55;
+}
+body.read-mode .ts-module-header[aria-expanded="true"] .ts-module-summary{display:block}
+body.read-mode .history-intro,
+body.read-mode .archives-text,
+body.read-mode .packet-intro,
+body.read-mode .pf-desc,
+body.read-mode .inv-bio,
+body.read-mode .term-def,
+body.read-mode .zine-desc,
+body.read-mode .osint-desc,
+body.read-mode .cve-desc,
+body.read-mode .lh-timeline .tl-desc,
+body.read-mode .lh-figure-card .lh-fig-bio,
+body.read-mode .pager-desc,
+body.read-mode .card-desc{
+  font-family:var(--sans);
+  font-size:1.02rem;
+  line-height:1.72;
+  color:#1f2430;
+}
+body.read-mode .term-visual,
+body.read-mode .pf-code,
+body.read-mode .ingredient-code,
+body.read-mode .vb6-code,
+body.read-mode .nfo{
+  font-size:0.84rem;
+  line-height:1.6;
+  color:#20303a;
+  background:#f3f2ee;
+  border-color:rgba(0,0,0,0.16);
+}
+body.read-mode .glossary-grid,
+body.read-mode .investigator-grid,
+body.read-mode .zine-grid,
+body.read-mode .osint-grid,
+body.read-mode .cve-list,
+body.read-mode .lh-figure-grid{
+  grid-template-columns:1fr;
+  max-width:780px;
+  margin-left:auto;
+  margin-right:auto;
+  gap:1rem;
+}
+body.read-mode .module-controls{
+  position:sticky;
+  top:4.2rem;
+  z-index:24;
+  width:min(920px,calc(100% - 1.5rem));
+  margin:0.5rem auto 1rem;
+}
+body.read-mode .top-bar{border-width:1px;box-shadow:0 1px 8px rgba(0,0,0,0.08)}
+body.read-mode .top-bar-label,body.read-mode .music-track-sub{
+  font-size:0.7rem;
+  letter-spacing:0.03em;
+  text-transform:none;
+}
+body.read-mode .top-toggle-btn{
+  font-size:0.72rem;
+  letter-spacing:0.02em;
+  text-transform:none;
+}
 .pi-link{position:fixed;right:clamp(0.8rem,2.4vw,1.2rem);bottom:clamp(3.4rem,7vw,4.2rem);z-index:10940;width:32px;height:32px;border-radius:50%;display:flex;align-items:center;justify-content:center;text-decoration:none;font-family:var(--mono);font-weight:700;font-size:0.95rem;color:var(--cyan);border:1px solid rgba(24,220,255,0.5);background:rgba(2,12,24,0.9);box-shadow:0 0 14px rgba(24,220,255,0.35),0 0 26px rgba(24,220,255,0.18);animation:piPulse 2.8s ease-in-out infinite}
 .pi-link:hover{border-color:var(--tron);box-shadow:0 0 18px rgba(24,220,255,0.5),0 0 34px rgba(24,220,255,0.24)}
 .pi-link:focus-visible{outline:2px solid var(--cyan);outline-offset:2px}

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,13 +53,13 @@
       <h2 class="ra-title">IDENTITY VERIFICATION REQUIRED</h2>
       <p class="ra-sub">Stand by for forensic intake and biometric gate validation.</p>
       <button type="button" id="requestAccessBtn" class="ra-btn">REQUEST ACCESS</button>
-      <form id="raPasswordForm" class="ra-password-form" hidden novalidate>
+      <form id="raPasswordForm" class="ra-password-form" hidden novalidate aria-hidden="true">
         <label class="ra-password-label" for="raPasswordInput">ENTER ACCESS CODE</label>
         <input type="password" id="raPasswordInput" class="ra-password-input"
-               autocomplete="off" autocapitalize="off" spellcheck="false"
+               autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" maxlength="64"
                aria-describedby="raPasswordHint" required>
-        <button type="submit" class="ra-btn ra-btn-submit">SUBMIT</button>
-        <p id="raPasswordHint" class="ra-password-hint" role="status" aria-live="polite"></p>
+        <button type="submit" id="raPasswordSubmit" class="ra-btn ra-btn-submit">SUBMIT</button>
+        <p id="raPasswordHint" class="ra-password-hint" role="status" aria-live="polite" aria-atomic="true"></p>
       </form>
     </div>
     <div class="ra-analyze" id="raAnalyze" aria-hidden="true">
@@ -405,7 +405,7 @@
     </svg>
   </div>
 
-  <main class="uniform-section-spacing">
+  <main class="uniform-section-spacing" id="mainContent">
 
     <!-- ====== STATS ====== -->
     <section class="stats-section reveal" id="statsSection" aria-label="Statistics" data-stats-pending>
@@ -498,7 +498,7 @@
         <h2 class="section-head"><span>//</span> recipe_index</h2>
         <div class="search-wrap legacy-search-wrap">
           <span class="search-icon" aria-hidden="true">&#128269;</span>
-          <input type="search" class="search-input" id="repoSearch" placeholder="Search recipes by name, language, or keyword&hellip;" aria-label="Search repositories">
+          <input type="search" class="search-input" id="repoSearch" placeholder="Search recipes by name, language, or keyword&hellip;" aria-label="Search repositories" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
         </div>
         <div class="project-grid" id="featuredGrid"></div>
         <div class="project-grid" id="projectGrid"><div class="loading-msg"><span class="spinner"></span>Loading recipes&hellip;</div></div>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -654,6 +654,58 @@ function parseDateMs(iso){var t=Date.parse(iso);return Number.isFinite(t)?t:null
 function esc(s){if(!s)return'';return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
 function safeUrl(u){if(!u||/^(javascript|data):/i.test(String(u)))return'#';try{var h=new URL(u);return(h.protocol==='https:'||h.protocol==='http:')&&(h.hostname==='github.com'||h.hostname.endsWith('.github.com')||h.hostname.endsWith('.github.io'))?u:'#'}catch(e){return'#'}}
 function relDate(iso){var ts=parseDateMs(iso);if(ts===null)return'unknown';var d=Math.floor((Date.now()-ts)/864e5);if(d<1)return'today';if(d<30)return d+'d ago';if(d<365)return Math.floor(d/30)+'mo ago';return Math.floor(d/365)+'y ago'}
+function emitSuperLiteConsoleView(data){
+  if(typeof console==='undefined')return;
+  var repos=(data&&Array.isArray(data.repos))?data.repos:[];
+  var stats=data&&data.stats?data.stats:{};
+  var featured=repos.filter(function(r){return !!r.featured}).slice(0,8).map(function(r){
+    return{
+      recipe:r.name||'unknown',
+      lang:r.language||'n/a',
+      stars:r.stars||0,
+      updated:relDate(r.last_updated)
+    };
+  });
+  var modules=[].slice.call(document.querySelectorAll('.ts-module')).slice(0,14).map(function(mod){
+    var head=mod.querySelector('.section-head');
+    var summary=mod.querySelector('.ts-module-summary');
+    return{
+      id:mod.id||'(no-id)',
+      topic:(head?head.textContent:'').replace(/\s+/g,' ').trim().replace(/^\/\//,'').trim()||'module',
+      summary:(summary?summary.textContent:'').replace(/\s+/g,' ').trim().slice(0,96)
+    };
+  });
+  var sourceMap={live:'live snapshot',cached:'cached snapshot',fallback:'static fallback file',embedded:'inline embedded fallback',error:'minimal emergency fallback'};
+  var mode=getSetting('display_mode','dark');
+  if(mode==='reading')mode='read';
+  var header=[
+    'THUMPERSECURE // SUPER LITE HEADLESS VIEW',
+    'NAME       code cookbook',
+    'PROFILE    osint + seo specialist',
+    'SYNOPSIS   fast console index of the live site state',
+    'SOURCE     '+(sourceMap[dataSource]||String(dataSource||'unknown')),
+    'MODE       '+String(mode||'dark'),
+    'TOOLS      '+String(stats.tools_count||repos.length||0),
+    'STARS      '+String(stats.stars_total||0),
+    'FEATURED   '+String(stats.featured_count||featured.length||0),
+    'FOLLOWERS  '+String(stats.followers||0),
+    'TIP        run TS.superLite() anytime to reprint'
+  ].join('\n');
+  console.groupCollapsed('%c[super-lite]%c headless site view','color:#18dcff;font-weight:700','color:#9db0cb');
+  console.log(header);
+  if(featured.length){
+    console.log('--- featured recipes ---');
+    if(console.table)console.table(featured);else console.log(featured);
+  }
+  if(modules.length){
+    console.log('--- module index ---');
+    if(console.table)console.table(modules);else console.log(modules);
+  }
+  console.groupEnd();
+}
+TS.superLite=function(){
+  emitSuperLiteConsoleView(siteData||getEmbeddedFallback()||{stats:{},repos:[]});
+};
 
 /* ====== RENDER FUNCTIONS ====== */
 function animateCounter(el,target){
@@ -768,6 +820,7 @@ if(searchInput){
   renderStats(data);
   buildFeaturedCards(data);
   renderProjectGrid(data);
+  emitSuperLiteConsoleView(data);
 })();
 
 /* ====== COLLAPSIBLE MODULES (Phase 4) ====== */

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -44,10 +44,47 @@
 window.TS = window.TS || {};
 var SETTINGS_KEY = 'ts_cookbook_settings';
 var SNAPSHOT_CACHE_KEY = 'ts_cookbook_snapshot';
+var ACCESS_CODE = 'integrity';
+var accessGranted = false;
 TS.operatorDossier = null;
 var modalOverflowCount=0;
 function lockBodyScroll(){modalOverflowCount++;if(modalOverflowCount===1)document.body.style.overflow='hidden'}
 function unlockBodyScroll(){modalOverflowCount=Math.max(0,modalOverflowCount-1);if(modalOverflowCount===0)document.body.style.overflow=''}
+function detectReloadNavigation(){
+  try{
+    var navEntries=performance&&performance.getEntriesByType?performance.getEntriesByType('navigation'):[];
+    if(navEntries&&navEntries.length&&navEntries[0]&&navEntries[0].type){
+      return navEntries[0].type==='reload';
+    }
+  }catch(e){}
+  try{
+    return !!(performance&&performance.navigation&&performance.navigation.type===1);
+  }catch(e){}
+  return false;
+}
+function resetStateOnReload(){
+  if(!detectReloadNavigation())return;
+  try{
+    localStorage.removeItem(SETTINGS_KEY);
+    localStorage.removeItem(SNAPSHOT_CACHE_KEY);
+    localStorage.removeItem('cb_puzzle_solved');
+    localStorage.removeItem('cb_puzzle_dismissed');
+  }catch(e){}
+  try{sessionStorage.removeItem('cb_rx_dismissed')}catch(e){}
+  try{
+    if(history&&'scrollRestoration' in history)history.scrollRestoration='manual';
+    if(location.hash&&history&&typeof history.replaceState==='function'){
+      history.replaceState(null,'',location.pathname+location.search);
+    }
+  }catch(e){}
+  try{window.scrollTo(0,0)}catch(e){}
+}
+resetStateOnReload();
+function markAccessGranted(){
+  if(accessGranted)return;
+  accessGranted=true;
+  window.dispatchEvent(new Event('ts:access-granted'));
+}
 
 function getSettings(){try{return JSON.parse(localStorage.getItem(SETTINGS_KEY))||{}}catch(e){return{}}}
 function saveSettings(s){try{localStorage.setItem(SETTINGS_KEY,JSON.stringify(s))}catch(e){}}
@@ -68,7 +105,8 @@ function waitForRequestAccess(){
     var form=document.getElementById('raPasswordForm');
     var input=document.getElementById('raPasswordInput');
     var hint=document.getElementById('raPasswordHint');
-    if(!ra||!btn){resolve();return}
+    var submitBtn=form?form.querySelector('button[type="submit"]'):null;
+    if(!ra||!btn){markAccessGranted();resolve();return}
     var HINTS=[
       'Hint: a core principle of secure operations.',
       'Hint: think honesty — the quality of being whole and undivided.',
@@ -77,7 +115,12 @@ function waitForRequestAccess(){
       'Hint: the word is "integrity" — try again.'
     ];
     var attemptIndex=0;
+    var isOpening=false;
+    var isSolved=false;
     function runAnalyze(){
+      if(isOpening)return;
+      isOpening=true;
+      markAccessGranted();
       if(analyze){
         analyze.classList.add('show');
         analyze.setAttribute('aria-hidden','false');
@@ -93,12 +136,20 @@ function waitForRequestAccess(){
       },reducedMotion?500:2200);
     }
     btn.addEventListener('click',function(){
+      if(isOpening)return;
       btn.disabled=true;
       btn.classList.add('hidden');
       if(form){
         form.hidden=false;
+        form.setAttribute('aria-hidden','false');
         form.classList.add('show');
-        if(input)setTimeout(function(){try{input.focus()}catch(e){}},120);
+        if(input){
+          input.disabled=false;
+          input.value='';
+          input.setAttribute('aria-invalid','false');
+          setTimeout(function(){try{input.focus()}catch(e){}},120);
+        }
+        if(submitBtn)submitBtn.disabled=false;
       }else{
         runAnalyze();
       }
@@ -106,16 +157,34 @@ function waitForRequestAccess(){
     if(form){
       form.addEventListener('submit',function(ev){
         ev.preventDefault();
-        if(!input)return;
+        if(isOpening||isSolved)return;
+        if(!input){runAnalyze();return}
         var value=(input.value||'').trim().toLowerCase();
-        if(value==='integrity'){
+        if(!value){
+          if(hint)hint.textContent='Enter access code.';
+          input.setAttribute('aria-invalid','true');
+          input.classList.remove('error');
+          void input.offsetWidth;
+          if(!reducedMotion)input.classList.add('error');
+          try{input.focus()}catch(e){}
+          return;
+        }
+        if(value===ACCESS_CODE){
+          isSolved=true;
           if(hint)hint.textContent='';
+          input.setAttribute('aria-invalid','false');
+          input.disabled=true;
+          if(submitBtn)submitBtn.disabled=true;
+          form.classList.remove('show');
           form.classList.add('hidden');
+          form.setAttribute('aria-hidden','true');
+          setTimeout(function(){form.hidden=true},320);
           runAnalyze();
           return;
         }
         if(hint)hint.textContent=HINTS[Math.min(attemptIndex,HINTS.length-1)];
         attemptIndex++;
+        input.setAttribute('aria-invalid','true');
         input.classList.remove('error');
         void input.offsetWidth;
         if(!reducedMotion)input.classList.add('error');
@@ -534,11 +603,11 @@ async function loadSiteData(){
   // Tier 1: Fetch live snapshot
   // Blue team: baseline normal before hunting anomalies — know what "good" looks like.
   if(!devMode){
+    var tid=null;
     try{
       var ctrl=new AbortController();
-      var tid=setTimeout(function(){ctrl.abort()},5000);
+      tid=setTimeout(function(){ctrl.abort()},5000);
       var r=await fetch(base+'data/site_snapshot.json',{signal:ctrl.signal});
-      clearTimeout(tid);
       if(r.ok){
         var d=await r.json();
         if(d&&d.repos&&d.repos.length>0){
@@ -548,6 +617,7 @@ async function loadSiteData(){
         }
       }
     }catch(e){/* fetch failed, try cache */}
+    finally{if(tid)clearTimeout(tid)}
   }
   // Tier 2: localStorage cache
   try{
@@ -560,10 +630,14 @@ async function loadSiteData(){
     }
   }catch(e){}
   // Tier 3: Fetch static fallback
+  var fbTimer=null;
   try{
-    var fb2=await fetch(base+'data/fallback-snapshot.json',{signal:(function(){var c=new AbortController();setTimeout(function(){c.abort()},3000);return c.signal})()});
+    var fbCtrl=new AbortController();
+    fbTimer=setTimeout(function(){fbCtrl.abort()},3000);
+    var fb2=await fetch(base+'data/fallback-snapshot.json',{signal:fbCtrl.signal});
     if(fb2.ok){var fd=await fb2.json();if(fd&&fd.repos&&fd.repos.length>0){siteData=fd;dataSource='fallback';return fd}}
   }catch(e){}
+  finally{if(fbTimer)clearTimeout(fbTimer)}
   // Tier 4: Embedded fallback (minimal inline)
   var fb=getEmbeddedFallback();
   if(fb&&fb.stats&&Array.isArray(fb.repos)){siteData=fb;dataSource='embedded';return fb}
@@ -679,11 +753,13 @@ function applyProjectFilter(q){
   });
 }
 if(searchInput){
+  searchInput.value='';
   searchInput.addEventListener('input',function(){
     var q=this.value.trim().toLowerCase();
     if(searchDebounceTimer){clearTimeout(searchDebounceTimer)}
     searchDebounceTimer=setTimeout(function(){applyProjectFilter(q)},100);
   });
+  applyProjectFilter('');
 }
 
 // Initialize data on load
@@ -835,7 +911,7 @@ var TRACK_CONFIG=[
   {local:'track - tron.m4a',query:'TRON Legacy Daft Punk soundtrack',label:'Tron — New Transmission'},
   {local:'Tron-Website-Music-Spoken-Words.m4a',query:'TRON 1982 End Titles Wendy Carlos',label:'Tron — Spoken Words'},
   {local:'Swordfish_track2-website.m4a',query:'Swordfish soundtrack Paul Oakenfold',label:'Swordfish — Track 2'},
-  {local:'Track3-Music-forwebsite.mp3',query:'Swordfish soundtrack Paul Oakenfold',label:'Track 3 — Music'} // The password is always swordfish.
+  {local:'Track3-Music-forwebsite.mp3',query:'Swordfish soundtrack Paul Oakenfold',label:'Track 3 — Music'}
 ];
 var mPlayer=document.getElementById('musicPlayer');
 var mStatus=document.getElementById('musicStatus');
@@ -864,6 +940,11 @@ var mLastTimePersist=0;
 var mDefaultVolume=0.7;
 var mBoostVolume=1;
 var mBoostAtSeconds=28;
+var mWatchdogTimer=null;
+var mManualPause=false;
+var mAccessGranted=accessGranted;
+var mBootMusicState=null;
+var mResumeInFlight=false;
 
 function isTrackIndex(i){return typeof i==='number'&&i>=0&&i<TRACK_CONFIG.length}
 function normalizeIndex(i){return isTrackIndex(i)?i:0}
@@ -952,6 +1033,34 @@ function showFallback(query){
 }
 function showAutoplayBanner(){if(autoplayBanner)autoplayBanner.classList.add('show')}
 function hideAutoplayBanner(){if(autoplayBanner)autoplayBanner.classList.remove('show')}
+function clearMusicWatchdog(){
+  if(!mWatchdogTimer)return;
+  clearTimeout(mWatchdogTimer);
+  mWatchdogTimer=null;
+}
+function scheduleMusicWatchdog(reason){
+  clearMusicWatchdog();
+  if(!mAccessGranted||mManualPause||!mPlayer||!mPlayer.src)return;
+  mWatchdogTimer=setTimeout(function(){verifyMusicPlayback(reason)},30000);
+}
+async function verifyMusicPlayback(reason){
+  mWatchdogTimer=null;
+  if(!mAccessGranted||mManualPause||!mPlayer||!isTrackIndex(mCurrentIndex))return;
+  if(!mPlayer.src||mPlayer.paused||mPlayer.ended){
+    var resumed=await attemptResumePlayback('watchdog-'+(reason||'state'));
+    if(resumed)scheduleMusicWatchdog('watchdog-recovered');
+    return;
+  }
+  var startTime=mPlayer.currentTime||0;
+  await sleep(1200);
+  if(!mPlayer||mManualPause||mPlayer.paused||!mPlayer.src)return;
+  if((mPlayer.currentTime||0)-startTime<0.15){
+    var recovered=await attemptResumePlayback('watchdog-'+(reason||'stalled'));
+    if(recovered)scheduleMusicWatchdog('watchdog-stall-recovered');
+    return;
+  }
+  scheduleMusicWatchdog('watchdog-healthy');
+}
 function schedulePlaybackStateSave(){
   if(mStateSaveTimer)return;
   mStateSaveTimer=setTimeout(function(){
@@ -995,16 +1104,17 @@ function debouncedResize(){
 }
 async function loadPreview(query){
   if(mCache[query]!==undefined)return mCache[query];
+  var tid=null;
   try{
     var ctrl=new AbortController();
-    var tid=setTimeout(function(){ctrl.abort()},6000);
+    tid=setTimeout(function(){ctrl.abort()},6000);
     var r=await fetch('https://itunes.apple.com/search?term='+encodeURIComponent(query)+'&entity=song&limit=8',{signal:ctrl.signal});
-    clearTimeout(tid);
     if(!r.ok)throw new Error('itunes '+r.status);
     var data=await r.json();
     var hit=(data.results||[]).find(function(x){return !!x.previewUrl})||null;
     mCache[query]=hit;return hit;
   }catch(e){mCache[query]=null;return null}
+  finally{if(tid)clearTimeout(tid)}
 }
 async function resolveTrackUrl(idx){
   if(!isTrackIndex(idx))return null;
@@ -1072,6 +1182,7 @@ async function playTrack(idx,opts){
     await mPlayer.play();
     if(gen!==mPlayGeneration)return;
     applyVolumeCurve();
+    mManualPause=false;
     setMusicStatus('playing: '+cfg.label.toLowerCase(),'playing');
     hideAutoplayBanner();
     mAutoplayPending=false;
@@ -1080,22 +1191,28 @@ async function playTrack(idx,opts){
     updateNowPlayingUI();
     updateTempoPulse();
     schedulePlaybackStateSave();
+    scheduleMusicWatchdog('play-track');
   }catch(e){
     if(gen!==mPlayGeneration)return;
     setMusicStatus('tap to play: '+cfg.label.toLowerCase(),null);
     showAutoplayBanner();
     mAutoplayPending=true;
+    clearMusicWatchdog();
     updatePlayPauseUI();
     updateMusicTrackIndicator();
     updateTempoPulse();
     schedulePlaybackStateSave();
   }
 }
-function attemptResumePlayback(source){
-  if(!mPlayer||!mPlayer.src||!isTrackIndex(mCurrentIndex))return;
+async function attemptResumePlayback(source){
+  if(mResumeInFlight)return false;
+  if(!mPlayer||!mPlayer.src||!isTrackIndex(mCurrentIndex))return false;
+  mResumeInFlight=true;
   applyVolumeCurve();
-  mPlayer.play().then(function(){
+  try{
+    await mPlayer.play();
     applyVolumeCurve();
+    mManualPause=false;
     setMusicStatus('playing: '+TRACK_CONFIG[mCurrentIndex].label.toLowerCase(),'playing');
     hideAutoplayBanner();
     mAutoplayPending=false;
@@ -1104,15 +1221,20 @@ function attemptResumePlayback(source){
     updateNowPlayingUI();
     updateTempoPulse();
     schedulePlaybackStateSave();
-  }).catch(function(){
-    if(source==='user')return;
+    scheduleMusicWatchdog('resume-'+(source||'unknown'));
+    return true;
+  }catch(err){
     setMusicStatus('tap to continue playback',null);
     showAutoplayBanner();
     mAutoplayPending=true;
+    clearMusicWatchdog();
     updatePlayPauseUI();
     updateTempoPulse();
     schedulePlaybackStateSave();
-  });
+    return false;
+  }finally{
+    mResumeInFlight=false;
+  }
 }
 function restartCurrentTrack(){
   if(!mPlayer||!isTrackIndex(mCurrentIndex))return;
@@ -1145,7 +1267,12 @@ function nextTrack(){
 function handlePlayPauseClick(){
   if(!mPlayer||!TRACK_CONFIG.length)return;
   if(!mPlayer.src){playTrack(isTrackIndex(mCurrentIndex)?mCurrentIndex:0,{autoplay:true,pushHistory:false});return}
-  if(mPlayer.paused){attemptResumePlayback('user');return}
+  if(mPlayer.paused){
+    attemptResumePlayback('user');
+    return;
+  }
+  mManualPause=true;
+  clearMusicWatchdog();
   mPlayer.pause();
   setMusicStatus('paused: '+TRACK_CONFIG[normalizeIndex(mCurrentIndex)].label.toLowerCase(),null);
   updatePlayPauseUI();
@@ -1170,14 +1297,33 @@ function loadMusicState(){
   mCurrentIndex=idx;
   return{idx:idx,time:typeof time==='number'?Math.max(0,time):0,shouldResume:!!shouldResume};
 }
+function handleAccessGrantedMusicKickoff(source){
+  if(mAccessGranted)return;
+  mAccessGranted=true;
+  var state=mBootMusicState||loadMusicState();
+  var targetIdx=isTrackIndex(state.idx)?state.idx:0;
+  if(!mPlayer||!TRACK_CONFIG.length)return;
+  if(!mPlayer.src){
+    playTrack(targetIdx,{autoplay:!!state.shouldResume,seekTime:state.time,pushHistory:false});
+    return;
+  }
+  if(state.shouldResume){
+    attemptResumePlayback(source||'access');
+  }else if(isTrackIndex(mCurrentIndex)){
+    setMusicStatus('ready: '+TRACK_CONFIG[mCurrentIndex].label.toLowerCase(),null);
+  }
+}
 function handleMusicVisibility(){
   if(document.hidden){
+    clearMusicWatchdog();
     savePlaybackState(true);
     return;
   }
   var shouldResume=getSetting('music_should_resume',false);
   if(shouldResume&&mPlayer&&mPlayer.src&&mPlayer.paused){
     attemptResumePlayback('visibility');
+  }else if(mPlayer&&mPlayer.src&&!mPlayer.paused){
+    scheduleMusicWatchdog('visibility-return');
   }
 }
 function handleMusicPageShow(e){
@@ -1235,15 +1381,24 @@ if(autoplayBanner){
     if(mAutoplayPending)attemptResumePlayback('gesture');
   },{passive:true});
 });
+document.addEventListener('keydown',function(e){
+  if(e.key!=='Enter'&&e.key!==' ')return;
+  if(mAutoplayPending)attemptResumePlayback('gesture-keyboard');
+});
 if(mPlayer){
-  mPlayer.addEventListener('ended',function(){nextTrack()});
+  mPlayer.addEventListener('ended',function(){
+    clearMusicWatchdog();
+    nextTrack();
+  });
   mPlayer.addEventListener('error',function(){
+    clearMusicWatchdog();
     setMusicStatus('audio source failed','error');
     updatePlayPauseUI();
     updateMusicTrackIndicator();
     updateTempoPulse();
   });
   mPlayer.addEventListener('pause',function(){
+    if(mManualPause)clearMusicWatchdog();
     updatePlayPauseUI();
     updateMusicTrackIndicator();
     updateNowPlayingUI();
@@ -1252,11 +1407,13 @@ if(mPlayer){
   });
   mPlayer.addEventListener('play',function(){
     applyVolumeCurve();
+    mManualPause=false;
     updatePlayPauseUI();
     updateMusicTrackIndicator();
     updateNowPlayingUI();
     updateTempoPulse();
     schedulePlaybackStateSave();
+    scheduleMusicWatchdog('player-play');
   });
   mPlayer.addEventListener('timeupdate',function(){
     applyVolumeCurve();
@@ -1264,17 +1421,21 @@ if(mPlayer){
   });
 }
 document.addEventListener('visibilitychange',handleMusicVisibility);
-window.addEventListener('pagehide',function(){savePlaybackState(true)});
-window.addEventListener('beforeunload',function(){savePlaybackState(true)});
+window.addEventListener('pagehide',function(){clearMusicWatchdog();savePlaybackState(true)});
+window.addEventListener('beforeunload',function(){clearMusicWatchdog();savePlaybackState(true)});
 window.addEventListener('pageshow',handleMusicPageShow);
 
-// Resume from stored preferences + maintain persistent playback
+// Prime music state but do not autoplay until access is granted.
 (function(){
-  var state=loadMusicState();
+  mBootMusicState=loadMusicState();
   updateNowPlayingUI();
   updateMusicTrackIndicator();
   updatePlayPauseUI();
-  playTrack(state.idx,{autoplay:state.shouldResume,seekTime:state.time,pushHistory:false});
+  playTrack(mBootMusicState.idx,{autoplay:false,seekTime:mBootMusicState.time,pushHistory:false});
+  if(accessGranted)handleAccessGrantedMusicKickoff('pre-granted');
+  window.addEventListener('ts:access-granted',function(){
+    handleAccessGrantedMusicKickoff('access-granted-event');
+  },{once:true});
 })();
 
 /* ====== AI DEFENSE EFFECTS (Phase 6) ====== */
@@ -1391,6 +1552,10 @@ function setDisplayMode(mode){
   modeDark=displayMode==='dark';
   setSetting('display_mode',displayMode);
   applyDisplayModeClass();
+  if(displayMode==='read'&&mPanel&&mPanelToggle){
+    setMusicPanelExpanded(false);
+    setSetting('music_panel_open',false);
+  }
   if(modeDark&&!reducedMotion){fxStart()}else{fxStop()}
   applyCanvasVisibility();
   updateModeUI();
@@ -2027,24 +2192,41 @@ if(reducedMotion){
 })();
 
 /* ====== INTERSECTION OBSERVER ====== */
-var rO=new IntersectionObserver(function(e){
-  e.forEach(function(en){
-    if(en.isIntersecting){
-      en.target.classList.add('visible');
-      rO.unobserve(en.target);
-      if(en.target.id==='statsSection'){en.target.classList.add('stats-live')}
-      if(en.target.id==='statsSection'&&statsPendingPairs){
+if('IntersectionObserver' in window){
+  var rO=new IntersectionObserver(function(e){
+    e.forEach(function(en){
+      if(en.isIntersecting){
+        en.target.classList.add('visible');
+        rO.unobserve(en.target);
+        if(en.target.id==='statsSection'){en.target.classList.add('stats-live')}
+        if(en.target.id==='statsSection'&&statsPendingPairs){
+          statsPendingPairs.forEach(function(p){
+            var el=document.getElementById(p[0]);
+            if(el&&p[1]!=null)animateCounter(el,p[1]);
+          });
+          statsPendingPairs=null;
+          if(en.target.removeAttribute)en.target.removeAttribute('data-stats-pending');
+        }
+      }
+    });
+  },{threshold:0.12});
+  document.querySelectorAll('.reveal').forEach(function(el){rO.observe(el)});
+}else{
+  document.querySelectorAll('.reveal').forEach(function(el){
+    el.classList.add('visible');
+    if(el.id==='statsSection'){
+      el.classList.add('stats-live');
+      if(statsPendingPairs){
         statsPendingPairs.forEach(function(p){
-          var el=document.getElementById(p[0]);
-          if(el&&p[1]!=null)animateCounter(el,p[1]);
+          var statEl=document.getElementById(p[0]);
+          if(statEl&&p[1]!=null)animateCounter(statEl,p[1]);
         });
         statsPendingPairs=null;
-        if(en.target.removeAttribute)en.target.removeAttribute('data-stats-pending');
+        if(el.removeAttribute)el.removeAttribute('data-stats-pending');
       }
     }
   });
-},{threshold:0.12});
-document.querySelectorAll('.reveal').forEach(function(el){rO.observe(el)});
+}
 
 /* ====== MOBILE: HERO PARALLAX & SCROLL PROGRESS ====== */
 var heroSection=document.getElementById('heroSection');


### PR DESCRIPTION

## Summary of Grade Up

- Hardened the request-access password flow to avoid accidental hint advancement, prevent duplicate opening transitions, and keep form accessibility state in sync.

- Added deterministic refresh reset behavior that clears persisted app/session state and URL hash on reload.

- Updated music behavior to start after access is granted, then verify playback after 30 seconds and retry when stalled/not playing.

- Improved read mode readability with larger/scannable typography, calmer color tokens, single-column content grids, and sticky module controls.

- Added a new **super-lite headless console view** that prints a man-page-style site summary in DevTools on visit, plus `TS.superLite()` to reprint on demand.

## Validation
- `node --check /workspace/docs/js/app.js`
- `rg "super-lite|TS\.superLite|emitSuperLiteConsoleView" /workspace/docs/js/app.js`

## Notes
- This turn focused on the console/headless experience; no UI artifact capture was needed.

